### PR TITLE
Fix example workflow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To create manifest of the current labels easily, using [label-exporter](https://
 
 ### Create Workflow
 
-An workflow example is here.
+An example workflow is here.
 
 ```yaml
 name: Sync labels
@@ -46,6 +46,7 @@ on:
       - master
     paths:
       - path/to/labels.yml
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Without it:

```
Check failure on line 1 in .github/workflows/labels.yml

GitHub Actions
/ .github/workflows/labels.yml

Invalid Workflow File
`build` is not a valid event name
```

https://github.com/hugovk/tinytext/actions/runs/40291801