### PR TITLE
Add option to specify custom repo and token

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ jobs:
           manifest: path/to/manifest/labels.yml
 ```
 
+## Sync labels on another repository
+
+It is also possible to specify a repository as an input to the action. This is useful if you want to store your labels somewhere centrally and modify multiple repository labels.
+
+\*\*Note: The default `GITHUB_TOKEN` will not have permissions to operate on other repositories so you must specify a personal access token in your secrets.
+
+```yaml
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - path/to/manifest/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: path/to/manifest/labels.yml
+          repository: myother/repository
+          token: ${{ secrets.PERSONAL_TOKEN }}
+```
+
 ## Project using action-label-syncer
 
 - [cloudalchemy/ansible-prometheus](https://github.com/cloudalchemy/ansible-prometheus)
@@ -81,25 +107,19 @@ If you're using `action-label-syncer` in your project, please send a PR to list 
 
 ## Note
 
-*Icon made by bqlqn from [www.flaticon.com](https://www.flaticon.com)*
+_Icon made by bqlqn from [www.flaticon.com](https://www.flaticon.com)_
 
 <!-- badge links -->
 
 [actions-workflow-test]: https://github.com/micnncim/action-label-syncer/actions?query=workflow%3ACI
 [actions-workflow-test-badge]: https://img.shields.io/github/workflow/status/micnncim/action-label-syncer/CI?label=CI&style=for-the-badge&logo=github
-
 [actions-marketplace]: https://github.com/marketplace/actions/label-syncer
 [actions-marketplace-badge]: https://img.shields.io/badge/marketplace-label%20syncer-blue?style=for-the-badge&logo=github
-
 [release]: https://github.com/micnncim/action-label-syncer/releases
 [release-badge]: https://img.shields.io/github/v/release/micnncim/action-label-syncer?style=for-the-badge&logo=github
-
 [pkg.go.dev]: https://pkg.go.dev/github.com/micnncim/action-label-syncer?tab=overview
 [pkg.go.dev-badge]: https://img.shields.io/badge/pkg.go.dev-reference-02ABD7?style=for-the-badge&logoWidth=25&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg1IDU1IDEyMCAxMjAiPjxwYXRoIGZpbGw9IiMwMEFERDgiIGQ9Ik00MC4yIDEwMS4xYy0uNCAwLS41LS4yLS4zLS41bDIuMS0yLjdjLjItLjMuNy0uNSAxLjEtLjVoMzUuN2MuNCAwIC41LjMuMy42bC0xLjcgMi42Yy0uMi4zLS43LjYtMSAuNmwtMzYuMi0uMXptLTE1LjEgOS4yYy0uNCAwLS41LS4yLS4zLS41bDIuMS0yLjdjLjItLjMuNy0uNSAxLjEtLjVoNDUuNmMuNCAwIC42LjMuNS42bC0uOCAyLjRjLS4xLjQtLjUuNi0uOS42bC00Ny4zLjF6bTI0LjIgOS4yYy0uNCAwLS41LS4zLS4zLS42bDEuNC0yLjVjLjItLjMuNi0uNiAxLS42aDIwYy40IDAgLjYuMy42LjdsLS4yIDIuNGMwIC40LS40LjctLjcuN2wtMjEuOC0uMXptMTAzLjgtMjAuMmMtNi4zIDEuNi0xMC42IDIuOC0xNi44IDQuNC0xLjUuNC0xLjYuNS0yLjktMS0xLjUtMS43LTIuNi0yLjgtNC43LTMuOC02LjMtMy4xLTEyLjQtMi4yLTE4LjEgMS41LTYuOCA0LjQtMTAuMyAxMC45LTEwLjIgMTkgLjEgOCA1LjYgMTQuNiAxMy41IDE1LjcgNi44LjkgMTIuNS0xLjUgMTctNi42LjktMS4xIDEuNy0yLjMgMi43LTMuN2gtMTkuM2MtMi4xIDAtMi42LTEuMy0xLjktMyAxLjMtMy4xIDMuNy04LjMgNS4xLTEwLjkuMy0uNiAxLTEuNiAyLjUtMS42aDM2LjRjLS4yIDIuNy0uMiA1LjQtLjYgOC4xLTEuMSA3LjItMy44IDEzLjgtOC4yIDE5LjYtNy4yIDkuNS0xNi42IDE1LjQtMjguNSAxNy05LjggMS4zLTE4LjktLjYtMjYuOS02LjYtNy40LTUuNi0xMS42LTEzLTEyLjctMjIuMi0xLjMtMTAuOSAxLjktMjAuNyA4LjUtMjkuMyA3LjEtOS4zIDE2LjUtMTUuMiAyOC0xNy4zIDkuNC0xLjcgMTguNC0uNiAyNi41IDQuOSA1LjMgMy41IDkuMSA4LjMgMTEuNiAxNC4xLjYuOS4yIDEuNC0xIDEuN3oiLz48cGF0aCBmaWxsPSIjMDBBREQ4IiBkPSJNMTg2LjIgMTU0LjZjLTkuMS0uMi0xNy40LTIuOC0yNC40LTguOC01LjktNS4xLTkuNi0xMS42LTEwLjgtMTkuMy0xLjgtMTEuMyAxLjMtMjEuMyA4LjEtMzAuMiA3LjMtOS42IDE2LjEtMTQuNiAyOC0xNi43IDEwLjItMS44IDE5LjgtLjggMjguNSA1LjEgNy45IDUuNCAxMi44IDEyLjcgMTQuMSAyMi4zIDEuNyAxMy41LTIuMiAyNC41LTExLjUgMzMuOS02LjYgNi43LTE0LjcgMTAuOS0yNCAxMi44LTIuNy41LTUuNC42LTggLjl6bTIzLjgtNDAuNGMtLjEtMS4zLS4xLTIuMy0uMy0zLjMtMS44LTkuOS0xMC45LTE1LjUtMjAuNC0xMy4zLTkuMyAyLjEtMTUuMyA4LTE3LjUgMTcuNC0xLjggNy44IDIgMTUuNyA5LjIgMTguOSA1LjUgMi40IDExIDIuMSAxNi4zLS42IDcuOS00LjEgMTIuMi0xMC41IDEyLjctMTkuMXoiLz48L3N2Zz4=
-
 [dependabot]: https://github.com/micnncim/action-label-syncer/pulls?q=is:pr%20author:app/dependabot-preview
 [dependabot-badge]: https://img.shields.io/badge/dependabot-enabled-blue?style=for-the-badge&logo=dependabot
-
 [license]: LICENSE
 [license-badge]: https://img.shields.io/github/license/micnncim/action-label-syncer?style=for-the-badge
-

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
 
 It is also possible to specify a repository as an input to the action. This is useful if you want to store your labels somewhere centrally and modify multiple repository labels.
 
-\*\*Note: The default `GITHUB_TOKEN` will not have permissions to operate on other repositories so you must specify a personal access token in your secrets.
+**Note: The default `GITHUB_TOKEN` will not have permissions to operate on other repositories so you must specify a personal access token in your secrets.**
 
 ```yaml
 name: Sync labels

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,20 @@
-name: 'Label Syncer'
-description: 'Sync GitHub labels in the declarative way.'
-author: 'micnncim'
+name: "Label Syncer"
+description: "Sync GitHub labels in the declarative way."
+author: "micnncim"
 inputs:
   manifest:
-    description: 'File path of YAML manifest for labels'
+    description: "File path of YAML manifest for labels"
     required: false
-    default: '.github/labels.yml'
+    default: ".github/labels.yml"
+  repository:
+    description: "The repo to sync labels on (defaults to current repo)"
+    required: false
+  token:
+    description: "An alternative GitHub token to use instead"
+    required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 branding:
   icon: circle
   color: black

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -31,10 +31,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := os.Getenv("INPUT_TOKEN")
+	if len(token) == 0 {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
 	client := github.NewClient(token)
 
-	repository := os.Getenv("GITHUB_REPOSITORY")
+	repository := os.Getenv("INPUT_REPOSITORY")
+	if len(repository) == 0 {
+		repository = os.Getenv("GITHUB_REPOSITORY")
+	}
 	slugs := strings.Split(repository, "/")
 	if len(slugs) != 2 {
 		fmt.Fprintf(os.Stderr, "invalid repository: %v\n", repository)

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
I have a use case where I want to store labels in a central repo and then have an action which syncs those labels with many other repos.

In order to do this it needs to be possible to set the repo as an input and also specify another access token with more permissions, like a personal access token stored in secrets.