### PR TITLE
Added all the repositories from Guild to the list of users for this action

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ jobs:
 - [sagebind/isahc](https://github.com/sagebind/isahc)
 - [JulienBreux/baleia](https://github.com/JulienBreux/baleia)
 - [Simplify4U](https://github.com/s4u)
+- [The Guild - Master Labels](https://github.com/the-guild-org/shared-resources)
+- [The Guild - GraphQL Codegen](https://github.com/dotansimha/graphql-code-generator)
+- [The Guild - GraphQL ESLint](https://github.com/dotansimha/graphql-eslint)
+- [The Guild - Apollo Angular](https://github.com/kamilkisiela/apollo-angular)
+- [The Guild - GraphQL Config](https://github.com/kamilkisiela/graphql-config)
+- [The Guild - GraphQL Mesh](https://github.com/Urigo/graphql-mesh)
+- [The Guild - GraphQL Modules](https://github.com/Urigo/graphql-modules)
+- [The Guild - GraphQL Inspector](https://github.com/kamilkisiela/graphql-inspector)
+- [The Guild - GraphQL Tools](https://github.com/ardatan/graphql-tools)
+- [The Guild - GraphQL Scalars](https://github.com/Urigo/graphql-scalars)
+- [The Guild - Whatsapp Clone](https://github.com/Urigo/WhatsApp-Clone-Tutorial)
+- [The Guild - GraphQL CLI](https://github.com/Urigo/graphql-cli)
+- [The Guild - SOFA](https://github.com/Urigo/SOFA)
+
 
 If you're using `action-label-syncer` in your project, please send a PR to list your project!
 


### PR DESCRIPTION
We, at The Guild are using this action to have labelling at a master level (pushing from https://github.com/the-guild-org/shared-resources/) and at the repo level for declarative labelling and syncing. Adding the list of repos we have this on to the README.

One feature request we have is the ability to rename labels by specifying a from and to like [this action](https://github.com/crazy-max/ghaction-github-labeler) provides using config like `from_name` in the yaml

Thanks for this project :-)