### PR TITLE
Multi repo input

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
+      - uses: davidxjohnson/action-label-syncer@v1
         with:
           manifest: path/to/manifest/labels.yml
-          repository: myother/repository
+          repository: |
+              asurion-private/pse-action-hello-world
+              asurion-private/pse-ssm-config-surveyor
+              asurion-private/pse-github-actions
+              asurion-private/pse-project-management
+              asurion-private/pse-yoda
+              asurion-private/pse-surveyor-api
+              asurion-private/pse-sbx-deploy-surveyor
+              asurion-private/pse-chart-poc
           token: ${{ secrets.PERSONAL_TOKEN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: davidxjohnson/action-label-syncer@v1
+      - uses: micnncim/action-label-syncer@v1
         with:
           manifest: path/to/manifest/labels.yml
           repository: |

--- a/README.md
+++ b/README.md
@@ -86,14 +86,8 @@ jobs:
         with:
           manifest: path/to/manifest/labels.yml
           repository: |
-              asurion-private/pse-action-hello-world
-              asurion-private/pse-ssm-config-surveyor
-              asurion-private/pse-github-actions
-              asurion-private/pse-project-management
-              asurion-private/pse-yoda
-              asurion-private/pse-surveyor-api
-              asurion-private/pse-sbx-deploy-surveyor
-              asurion-private/pse-chart-poc
+              myorg/myrepo1
+              myorg/myrepo2
           token: ${{ secrets.PERSONAL_TOKEN }}
 ```
 

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+
 	"strconv"
 	"strings"
 
@@ -38,26 +39,29 @@ func main() {
 	}
 	client := github.NewClient(token)
 
-	repository := os.Getenv("INPUT_REPOSITORY")
-	if len(repository) == 0 {
-		repository = os.Getenv("GITHUB_REPOSITORY")
-	}
-	slugs := strings.Split(repository, "/")
-	if len(slugs) != 2 {
-		fmt.Fprintf(os.Stderr, "invalid repository: %v\n", repository)
-		os.Exit(1)
-	}
-	owner, repo := slugs[0], slugs[1]
-
 	prune, err := strconv.ParseBool(os.Getenv("INPUT_PRUNE"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to parse prune: %v\n", err)
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
-	if err := client.SyncLabels(ctx, owner, repo, labels, prune); err != nil {
-		fmt.Fprintf(os.Stderr, "unable to sync labels: %v\n", err)
-		os.Exit(1)
+	repoinput := os.Getenv("INPUT_REPOSITORY")
+	if len(repoinput) == 0 {
+		repoinput = os.Getenv("GITHUB_REPOSITORY")
+	}
+	repolist := strings.Fields(repoinput)
+	for _, repoitem := range repolist {
+		slugs := strings.Split(repoitem, "/")
+		if len(slugs) != 2 {
+			fmt.Fprintf(os.Stderr, "invalid repository: %v\n", repoitem)
+			os.Exit(1)
+		}
+		owner, repo := slugs[0], slugs[1]
+
+		ctx := context.Background()
+		if err := client.SyncLabels(ctx, owner, repo, labels, prune); err != nil {
+			fmt.Fprintf(os.Stderr, "unable to sync labels: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -49,8 +49,8 @@ func main() {
 	if len(repoinput) == 0 {
 		repoinput = os.Getenv("GITHUB_REPOSITORY")
 	}
-	repolist := strings.Fields(repoinput)
-	//repolist := strings.Split(repoinput, ` `)
+
+	repolist := strings.Fields(repoinput) // splits repo input based on whitespace
 	for _, repoitem := range repolist {
 		slugs := strings.Split(repoitem, "/")
 		if len(slugs) != 2 {
@@ -58,8 +58,8 @@ func main() {
 			os.Exit(1)
 		}
 		owner, repo := slugs[0], slugs[1]
-
 		ctx := context.Background()
+
 		if err := client.SyncLabels(ctx, owner, repo, labels, prune); err != nil {
 			fmt.Fprintf(os.Stderr, "unable to sync labels: %v\n", err)
 			os.Exit(1)

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -50,6 +50,7 @@ func main() {
 		repoinput = os.Getenv("GITHUB_REPOSITORY")
 	}
 	repolist := strings.Fields(repoinput)
+	//repolist := strings.Split(repoinput, ` `)
 	for _, repoitem := range repolist {
 		slugs := strings.Split(repoitem, "/")
 		if len(slugs) != 2 {

--- a/go.sum
+++ b/go.sum
@@ -24,4 +24,5 @@ gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Minor mods to accommodate multi-repo input from the workflow. 

- [x] Repo names are assumed to be delimited by white-space.
- [x] A range loop was added to repeat the same procedure for each repo listed in the input.
- [x] Documentation updated with workflow example.