### PR TITLE
feat: Label renaming and import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ renaming labels rather than deleting and creating new ones, existing
 pull requests and issues will keep their labels, but will adopt the
 new name.
 
+You can also set multiple aliases, which can be useful when reusing a
+configuration across multiple repositories, each of which may have a different
+existing label.  For example:
+
+```yaml
+- name: Type: bug
+  aliases:
+    - bug
+    - defect
+    - "Seriously, what was I thinking?"
+  description: Something isn't working
+  color: d73a4a
+```
+
+### Import statements
+
+To reuse some common configurations across repositories, add an item with just
+one field called `import`, which contains a path to another yaml file.  The
+contents of the imported file will be treated as if they appeared in the main
+file.  For example:
+
+```yaml
+# Common label definitions for all projects, such as "Type: bug".
+- import: common.yaml
+
+# Labels specific to this project:
+- name: Platform: iOS
+  description: Issues specific to iOS
+  color: d7ea4a
+```
+
 ### Create Workflow
 
 An example workflow is here.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ The default file path is `.github/labels.yml`, but you can specify any file path
 
 To create manifest of the current labels easily, using [label-exporter](https://github.com/micnncim/label-exporter) is recommended.
 
+### Renaming labels
+
+If you want to rename a label, you can set an `alias` in the manifest.
+For example, if you want to rename the label `bug` to `Type: bug`, you
+would use a manifest like this:
+
+```yaml
+- name: Type: bug
+  alias: bug
+  description: Something isn't working
+  color: d73a4a
+```
+
+Renaming labels makes it easier to adopt a new taxonomy if you have
+issues and pull requests using the old label names. Since you're
+renaming labels rather than deleting and creating new ones, existing
+pull requests and issues will keep their labels, but will adopt the
+new name.
+
 ### Create Workflow
 
 An example workflow is here.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Remove unmanaged labels from repository"
     required: false
     default: true
+  dry_run:
+    description: "Print what would be done, but do nothing"
+    required: false
+    default: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -77,7 +77,7 @@ func run(ctx context.Context) error {
 		owner, repo := s[0], s[1]
 
 		if err := client.SyncLabels(ctx, owner, repo, labels, prune, dryRun); err != nil {
-			err = multierr.Append(err, fmt.Errorf("unable to sync labels: %w", err))
+			return fmt.Errorf("unable to sync labels: %w", err)
 		}
 	}
 

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -44,6 +44,15 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("unable to parse prune: %w", err)
 	}
 
+	dryRun := false
+	dryRunEnv := os.Getenv("INPUT_DRY_RUN")
+	if dryRunEnv != "" {
+		dryRun, err = strconv.ParseBool(os.Getenv("INPUT_DRY_RUN"))
+		if err != nil {
+			return fmt.Errorf("unable to parse dry-run: %w", err)
+		}
+	}
+
 	token := os.Getenv("INPUT_TOKEN")
 	if len(token) == 0 {
 		token = os.Getenv("GITHUB_TOKEN")
@@ -67,7 +76,7 @@ func run(ctx context.Context) error {
 		}
 		owner, repo := s[0], s[1]
 
-		if err := client.SyncLabels(ctx, owner, repo, labels, prune); err != nil {
+		if err := client.SyncLabels(ctx, owner, repo, labels, prune, dryRun); err != nil {
 			err = multierr.Append(err, fmt.Errorf("unable to sync labels: %w", err))
 		}
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -33,6 +33,7 @@ type Client struct {
 type Label struct {
 	Name        string `yaml:"name"`
 	Alias       string `yaml:"alias"`
+	Aliases   []string `yaml:"aliases"`
 	Description string `yaml:"description"`
 	Color       string `yaml:"color"`
 }
@@ -65,6 +66,9 @@ func (c *Client) SyncLabels(ctx context.Context, owner, repo string, labels []La
 		labelMap[l.Name] = l
 		if l.Alias != "" {
 			aliasMap[l.Alias] = l
+		}
+		for _, alias := range l.Aliases {
+			aliasMap[alias] = l
 		}
 	}
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -143,7 +143,7 @@ func (c *Client) SyncLabels(ctx context.Context, owner, repo string, labels []La
 			if currentLabel.Description != l.Description || currentLabel.Color != l.Color || currentLabel.Name != l.Name {
 				return c.updateLabel(ctx, owner, repo, labelName, l)
 			}
-			fmt.Printf("label: %+v not changed on %s/%s\n", l, owner, repo)
+			// fmt.Printf("label: %+v not changed on %s/%s\n", l, owner, repo)
 			return nil
 		})
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -148,7 +148,7 @@ func (c *Client) SyncLabels(ctx context.Context, owner, repo string, labels []La
 			if currentLabel.Description != l.Description || currentLabel.Color != l.Color || currentLabel.Name != l.Name {
 				return c.updateLabel(ctx, owner, repo, labelName, l, dryRun)
 			}
-			// fmt.Printf("label: %+v not changed on %s/%s\n", l, owner, repo)
+			//fmt.Printf("Not changed: \"%s\" on %s/%s\n", l.Name, owner, repo)
 			return nil
 		})
 	}
@@ -162,7 +162,7 @@ func (c *Client) createLabel(ctx context.Context, owner, repo string, label Labe
 		Description: &label.Description,
 		Color:       &label.Color,
 	}
-	fmt.Printf("label: %+v created on: %s/%s\n", label, owner, repo)
+	fmt.Printf("Created: \"%s\" on %s/%s\n", label.Name, owner, repo)
 	if dryRun {
 		return nil
 	}
@@ -201,7 +201,11 @@ func (c *Client) updateLabel(ctx context.Context, owner, repo, labelName string,
 		Description: &label.Description,
 		Color:       &label.Color,
 	}
-	fmt.Printf("label %+v updated on: %s/%s\n", label, owner, repo)
+	if labelName != label.Name {
+		fmt.Printf("Renamed: \"%s\" => \"%s\" on %s/%s\n", labelName, label.Name, owner, repo)
+	} else {
+		fmt.Printf("Updated: \"%s\" on %s/%s\n", label.Name, owner, repo)
+	}
 	if dryRun {
 		return nil
 	}
@@ -210,7 +214,7 @@ func (c *Client) updateLabel(ctx context.Context, owner, repo, labelName string,
 }
 
 func (c *Client) deleteLabel(ctx context.Context, owner, repo, name string, dryRun bool) error {
-	fmt.Printf("label: %s deleted from: %s/%s\n", name, owner, repo)
+	fmt.Printf("Deleted: \"%s\" on %s/%s\n", name, owner, repo)
 	if dryRun {
 		return nil
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -62,10 +62,8 @@ func FromManifestToLabels(path string) ([]Label, error) {
 			}
 			flatLabels = append(flatLabels, l)
 		} else {
-			var importPath string
-			importPath = filepath.Join(filepath.Dir(path), l.Import)
-			var importedLabels []Label
-			importedLabels, err = FromManifestToLabels(importPath)
+			importPath := filepath.Join(filepath.Dir(path), l.Import)
+			importedLabels, err := FromManifestToLabels(importPath)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -57,6 +57,9 @@ func FromManifestToLabels(path string) ([]Label, error) {
 	var flatLabels []Label
 	for _, l := range labels {
 		if l.Import == "" {
+			if len(l.Description) > 100 {
+				return nil, fmt.Errorf("Description of \"%s\" exceeds 100 characters", l.Name)
+			}
 			flatLabels = append(flatLabels, l)
 		} else {
 			var importPath string

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -58,6 +59,9 @@ func FromManifestToLabels(path string) ([]Label, error) {
 			// Data checks and normalization.
 			if len(l.Description) > 100 {
 				return nil, fmt.Errorf("Description of \"%s\" exceeds 100 characters", l.Name)
+			}
+			if strings.Contains(l.Name, "?") {
+				return nil, fmt.Errorf("Label name cannot contain question marks: \"%s\"", l.Name)
 			}
 			if l.Alias != "" {
 				l.Aliases = append(l.Aliases, l.Alias)


### PR DESCRIPTION
This adds two main features: label renaming and import statements.

Label renaming is an extension of the work done by @larsks in PR #60.  To the renaming support in #60 (`alias` field), I added a list-of-strings field called `aliases`, to better support single configs that can be used across repositories.  For example, each repo could have a different existing bug label that you may to rename to unify them:

```yaml
- name: "Type: bug"
  aliases:
    - bug
    - defect
  description: Something isn't working
  color: d73a4a
```

The import statement further enhances our ability to share configs across repos.  Common fields needed by all repos (such as `Type: bug`) could be placed in a common config file.  Then, each repo has its own config file with its unique labels, and the common ones get imported.  For example:

```yaml
# common.yaml
- name: "Type: bug"
  aliases:
    - bug
    - defect
  description: Something isn't working
  color: d73a4a
```

```yaml
# repo1.yaml
- import: common.yaml

- name: "Platform: iOS"
  description: Issues specific to iOS
  color: d73a4a
```

Finally, this makes some additional changes I found useful in testing and development:
 - Error early instead of trying to change a label with a question mark in the name.
 - Error early if description is too long.  GitHub will reject these labels, so we should identify them early and provide a clear message.
 - Serialize label changes.  Doing them in parallel does not make the process much faster, but it does make the logs more difficult to read.
 - Fix silent errors from main.
 - Add dry-run flag.  Useful for testing a large migration before making it final.

Closes #59