### PR TITLE
Add support for GitHub Enterprise Server and GitHub AE

### DIFF
--- a/.github/workflows/label-syncer.yml
+++ b/.github/workflows/label-syncer.yml
@@ -6,8 +6,6 @@ on:
       - '.github/labels.yml'
     branches:
       - master
-  workflow_dispatch:
-
 jobs:
   build:
     name: Sync labels

--- a/.github/workflows/label-syncer.yml
+++ b/.github/workflows/label-syncer.yml
@@ -6,6 +6,8 @@ on:
       - '.github/labels.yml'
     branches:
       - master
+  workflow_dispatch:
+
 jobs:
   build:
     name: Sync labels

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
-![logo](docs/assets/logo.png)
-
-[![actions-workflow-test][actions-workflow-test-badge]][actions-workflow-test]
-[![actions-marketplace][actions-marketplace-badge]][actions-marketplace]
-[![release][release-badge]][release]
-[![pkg.go.dev][pkg.go.dev-badge]][pkg.go.dev]
-[![dependabot][dependabot-badge]][dependabot]
-[![license][license-badge]][license]
+## Heads up
+⚠️ ‼️ I'm archiving this fork, as GHES and GHAE customers should use https://github.com/github/safe-settings#the-settings-file for this instead
 
 GitHub Actions workflow to sync GitHub labels in the declarative way.
 

--- a/cmd/action-label-syncer/main.go
+++ b/cmd/action-label-syncer/main.go
@@ -48,7 +48,10 @@ func run(ctx context.Context) error {
 	if len(token) == 0 {
 		token = os.Getenv("GITHUB_TOKEN")
 	}
-	client := github.NewClient(token)
+
+	rawurl := os.Getenv("GITHUB_API_URL")
+
+	client := github.NewClient(token, rawurl)
 
 	repository := os.Getenv("INPUT_REPOSITORY")
 	if len(repository) == 0 {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -46,14 +46,18 @@ func FromManifestToLabels(path string) ([]Label, error) {
 	return labels, err
 }
 
-func NewClient(token string) *Client {
+func NewClient(token string, rawurl string) *Client {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	tc := oauth2.NewClient(ctx, ts)
+	githubClient, err := github.NewEnterpriseClient(rawurl, rawurl, tc)
+	if err != nil {
+		panic(err)
+	}
 	return &Client{
-		githubClient: github.NewClient(tc),
+		githubClient: githubClient,
 	}
 }
 


### PR DESCRIPTION
👋🏻 Hello!  This PR should fix #63 and also add support for GitHub AE.  These two products use a different API endpoint than GitHub.com, but the functionality of the API is the same here.

To solve this, the `GITHUB_API_URL` environment variable from the Actions runner is also picked up and shoved into the GitHub client.  I used the `NewEnterpriseClient` function from `go-github`, which is a wrapper that specifies the API url in addition to the HTTP client ([link](https://pkg.go.dev/github.com/google/go-github/github?utm_source=godoc#NewEnterpriseClient)).  It still works exactly as expected for **ALL** github.com plans, as seen in my free-tier fork of this repo in the run [here](https://github.com/some-natalie/action-label-syncer/actions/runs/1946492744).

I've also got it working exactly as expected in GitHub Enterprise Server, as seen in the screenshot below.  (side note - sorry for the screenshots, but I don't have anything publicly accessible to show off here)

<img width="1694" alt="Screen Shot 2022-03-07 at 9 32 03 AM" src="https://user-images.githubusercontent.com/9995618/157076399-522f745e-0fbf-464b-a8ac-2f41f738431f.png">

